### PR TITLE
Fix GQL parsing, typing, and RETURN * semantics

### DIFF
--- a/src/gql_binder.cpp
+++ b/src/gql_binder.cpp
@@ -267,7 +267,7 @@ shared_ptr<GqlBoundExpression> GqlBinder::BindExpression(const GqlExpression &ex
 			throw BinderException("GQL element_id argument must be a node or edge");
 		}
 		result->binding_index = result->left->binding_index;
-		result->result_type = {GqlTypeId::ELEMENT_ID, false};
+		result->result_type = {GqlTypeId::ELEMENT_ID, result->left->result_type.nullable};
 		return result;
 	case GqlExpressionType::FUNCTION: {
 		for (const auto &argument : expression.arguments) {
@@ -286,19 +286,24 @@ shared_ptr<GqlBoundExpression> GqlBinder::BindExpression(const GqlExpression &ex
 			throw BinderException("GQL function '%s' requires an argument", expression.function_name);
 		}
 		if (name == "coalesce") {
-			result->result_type = result->arguments[0]->result_type;
-			result->result_type.nullable = true;
+			result->result_type = {GqlTypeId::NULL_VALUE, true};
 			for (const auto &argument : result->arguments) {
-				if (result->result_type.id == GqlTypeId::PROPERTY_VALUE &&
-				    argument->result_type.id != GqlTypeId::PROPERTY_VALUE) {
+				if (argument->result_type.id == GqlTypeId::NULL_VALUE) {
+					continue;
+				}
+				if (result->result_type.id == GqlTypeId::NULL_VALUE ||
+				    (result->result_type.id == GqlTypeId::PROPERTY_VALUE &&
+				     argument->result_type.id != GqlTypeId::PROPERTY_VALUE)) {
 					result->result_type.id = argument->result_type.id;
-				} else if (argument->result_type.id != GqlTypeId::PROPERTY_VALUE &&
-				           result->result_type.id != argument->result_type.id) {
+				} else if (argument->result_type.id == GqlTypeId::PROPERTY_VALUE ||
+				           result->result_type.id == argument->result_type.id) {
+					// PROPERTY_VALUE is refined by any concrete peer type.
+				} else if (IsNumeric(result->result_type.id) && IsNumeric(argument->result_type.id)) {
+					result->result_type.id = NumericResult(result->result_type, argument->result_type).id;
+				} else {
 					throw BinderException("GQL COALESCE arguments must have compatible types");
 				}
-				if (!argument->result_type.nullable) {
-					result->result_type.nullable = false;
-				}
+				result->result_type.nullable = result->result_type.nullable && argument->result_type.nullable;
 			}
 			return result;
 		}
@@ -534,7 +539,7 @@ GqlLogicalPlan GqlBinder::Bind(const GqlMatchStatement &statement) {
 					binding.name = element.variable.value;
 					binding.index = bound_element.binding_index;
 					binding.type = {element.type == GqlPatternElementType::VERTEX ? GqlTypeId::NODE : GqlTypeId::EDGE,
-					                false};
+					                pattern.optional};
 					binding.source = element.variable.source;
 					DefineBinding(std::move(binding));
 				}
@@ -1178,16 +1183,51 @@ GqlLogicalPlan GqlBinder::Bind(const GqlMatchStatement &statement) {
 			project->distinct = true;
 		}
 	} else {
-		for (const auto &projection : statement.projections) {
-			if (!projection.expression) {
-				throw InternalException("GQL MATCH contains an empty projection");
+		if (statement.return_all) {
+			unordered_set<string> visible_names;
+			for (const auto &entry : let_bindings) {
+				visible_names.insert(entry.first);
 			}
-			auto expression = BindExpression(*projection.expression);
-			GqlBoundProjection bound_projection;
-			bound_projection.name = ProjectionName(projection, *expression);
-			bound_projection.expression = std::move(expression);
-			bound_projection.source = projection.source;
-			project->projections.push_back(std::move(bound_projection));
+			auto scope_index = current_scope;
+			while (scope_index != DConstants::INVALID_INDEX) {
+				if (scope_index >= scopes.size()) {
+					throw InternalException("GQL binder scope parent is invalid");
+				}
+				for (const auto &entry : scopes[scope_index].bindings) {
+					visible_names.insert(entry.first);
+				}
+				scope_index = scopes[scope_index].parent;
+			}
+			vector<string> sorted_names(visible_names.begin(), visible_names.end());
+			std::sort(sorted_names.begin(), sorted_names.end());
+			for (const auto &name : sorted_names) {
+				GqlIdentifier identifier;
+				identifier.value = name;
+				auto binding_index = FindBindingIndex(name);
+				if (binding_index != DConstants::INVALID_INDEX) {
+					identifier.source = bindings[binding_index].source;
+				}
+				GqlExpression expression;
+				expression.type = GqlExpressionType::VARIABLE_REFERENCE;
+				expression.variable = identifier;
+				expression.source = identifier.source;
+				project->projections.push_back({BindExpression(expression), name, identifier.source});
+			}
+			if (project->projections.empty()) {
+				throw BinderException("GQL RETURN * requires at least one visible variable");
+			}
+		} else {
+			for (const auto &projection : statement.projections) {
+				if (!projection.expression) {
+					throw InternalException("GQL MATCH contains an empty projection");
+				}
+				auto expression = BindExpression(*projection.expression);
+				GqlBoundProjection bound_projection;
+				bound_projection.name = ProjectionName(projection, *expression);
+				bound_projection.expression = std::move(expression);
+				bound_projection.source = projection.source;
+				project->projections.push_back(std::move(bound_projection));
+			}
 		}
 	}
 	project->visible_projection_count = project->projections.size();
@@ -1205,8 +1245,7 @@ GqlLogicalPlan GqlBinder::Bind(const GqlMatchStatement &statement) {
 		}
 		if (bound_order.projection_index == DConstants::INVALID_INDEX) {
 			if (statement.distinct || saw_call_clause) {
-				throw BinderException(
-				    "GQL ORDER BY expressions must appear in RETURN when DISTINCT or CALL is used");
+				throw BinderException("GQL ORDER BY expressions must appear in RETURN when DISTINCT or CALL is used");
 			}
 			bound_order.projection_index = project->projections.size();
 			GqlBoundProjection hidden_order;

--- a/src/gql_parser.cpp
+++ b/src/gql_parser.cpp
@@ -21,6 +21,7 @@
 #include "gql_transformer.hpp"
 
 #include <cctype>
+#include <initializer_list>
 
 namespace duckdb {
 
@@ -34,7 +35,8 @@ static idx_t SkipGqlTrivia(const string &query, idx_t offset = 0) {
 			offset++;
 			continue;
 		}
-		if (offset + 1 < query.size() && query[offset] == '-' && query[offset + 1] == '-') {
+		if (offset + 1 < query.size() && ((query[offset] == '-' && query[offset + 1] == '-') ||
+		                                  (query[offset] == '/' && query[offset + 1] == '/'))) {
 			offset += 2;
 			while (offset < query.size() && query[offset] != '\n') {
 				offset++;
@@ -54,8 +56,42 @@ static idx_t SkipGqlTrivia(const string &query, idx_t offset = 0) {
 	return offset;
 }
 
-static string NormalizedGqlStart(const string &query) {
-	return StringUtil::Upper(query.substr(SkipGqlTrivia(query)));
+static bool ConsumeGqlKeyword(const string &query, idx_t &offset, const string &keyword) {
+	offset = SkipGqlTrivia(query, offset);
+	if (offset + keyword.size() > query.size() ||
+	    !StringUtil::CIEquals(query.substr(offset, keyword.size()), keyword)) {
+		return false;
+	}
+	auto end = offset + keyword.size();
+	if (end < query.size() && (std::isalnum(static_cast<unsigned char>(query[end])) || query[end] == '_')) {
+		return false;
+	}
+	offset = end;
+	return true;
+}
+
+static bool StartsWithGqlKeywords(const string &query, std::initializer_list<const char *> keywords,
+                                  idx_t *end_offset = nullptr) {
+	idx_t offset = 0;
+	for (const auto keyword : keywords) {
+		if (!ConsumeGqlKeyword(query, offset, keyword)) {
+			return false;
+		}
+	}
+	if (end_offset) {
+		*end_offset = offset;
+	}
+	return true;
+}
+
+static bool StartsWithGqlKeywordsAndCharacter(const string &query, std::initializer_list<const char *> keywords,
+                                              char character) {
+	idx_t offset;
+	if (!StartsWithGqlKeywords(query, keywords, &offset)) {
+		return false;
+	}
+	offset = SkipGqlTrivia(query, offset);
+	return offset < query.size() && query[offset] == character;
 }
 
 static vector<string> SplitGqlOverrideQueries(const string &query) {
@@ -83,12 +119,8 @@ static vector<string> SplitGqlOverrideQueries(const string &query) {
 }
 
 static bool StartsWithMergePattern(const string &query) {
-	auto offset = SkipGqlTrivia(query);
-	if (offset + 5 > query.size() || !StringUtil::CIEquals(query.substr(offset, 5), "MERGE")) {
-		return false;
-	}
-	offset += 5;
-	if (offset < query.size() && (std::isalnum(static_cast<unsigned char>(query[offset])) || query[offset] == '_')) {
+	idx_t offset;
+	if (!StartsWithGqlKeywords(query, {"MERGE"}, &offset)) {
 		return false;
 	}
 	offset = SkipGqlTrivia(query, offset);
@@ -96,12 +128,8 @@ static bool StartsWithMergePattern(const string &query) {
 }
 
 static bool FindAlgorithmCall(const string &query, idx_t &algorithm_offset) {
-	auto offset = SkipGqlTrivia(query);
-	if (offset + 4 > query.size() || !StringUtil::CIEquals(query.substr(offset, 4), "CALL")) {
-		return false;
-	}
-	offset += 4;
-	if (offset < query.size() && (std::isalnum(static_cast<unsigned char>(query[offset])) || query[offset] == '_')) {
+	idx_t offset;
+	if (!StartsWithGqlKeywords(query, {"CALL"}, &offset)) {
 		return false;
 	}
 	offset = SkipGqlTrivia(query, offset);
@@ -218,16 +246,15 @@ public:
 };
 
 static bool StartsWithGqlCommand(const string &query) {
-	auto normalized = NormalizedGqlStart(query);
-	return StringUtil::StartsWith(normalized, "CREATE GRAPH") ||
-	       StringUtil::StartsWith(normalized, "CREATE PROPERTY GRAPH") ||
-	       StringUtil::StartsWith(normalized, "DROP GRAPH") ||
-	       StringUtil::StartsWith(normalized, "DROP PROPERTY GRAPH") ||
-	       StringUtil::StartsWith(normalized, "SESSION SET GRAPH") ||
-	       StringUtil::StartsWith(normalized, "SESSION SET PROPERTY GRAPH") ||
-	       StringUtil::StartsWith(normalized, "COPY GRAPH") || StartsWithMergePattern(query) ||
-	       StringUtil::StartsWith(normalized, "MATCH") || StringUtil::StartsWith(normalized, "OPTIONAL MATCH") ||
-	       StringUtil::StartsWith(normalized, "INSERT (") || StartsWithAlgorithmCall(query);
+	return StartsWithGqlKeywords(query, {"CREATE", "GRAPH"}) ||
+	       StartsWithGqlKeywords(query, {"CREATE", "PROPERTY", "GRAPH"}) ||
+	       StartsWithGqlKeywords(query, {"DROP", "GRAPH"}) ||
+	       StartsWithGqlKeywords(query, {"DROP", "PROPERTY", "GRAPH"}) ||
+	       StartsWithGqlKeywords(query, {"SESSION", "SET", "GRAPH"}) ||
+	       StartsWithGqlKeywords(query, {"SESSION", "SET", "PROPERTY", "GRAPH"}) ||
+	       StartsWithGqlKeywords(query, {"COPY", "GRAPH"}) || StartsWithMergePattern(query) ||
+	       StartsWithGqlKeywords(query, {"MATCH"}) || StartsWithGqlKeywords(query, {"OPTIONAL", "MATCH"}) ||
+	       StartsWithGqlKeywordsAndCharacter(query, {"INSERT"}, '(') || StartsWithAlgorithmCall(query);
 }
 
 static bool RewriteAlgorithmCall(const string &query, string &rewritten) {
@@ -1289,27 +1316,25 @@ private:
 };
 
 static void ValidateExecutionHint(const string &query) {
-	auto trimmed = query.substr(SkipGqlTrivia(query));
-	auto upper = StringUtil::Upper(trimmed);
 	idx_t offset;
-	if (StringUtil::StartsWith(upper, "OPTIONAL MATCH")) {
-		offset = string("OPTIONAL MATCH").size();
-	} else if (StringUtil::StartsWith(upper, "MATCH")) {
-		offset = string("MATCH").size();
+	if (StartsWithGqlKeywords(query, {"OPTIONAL", "MATCH"}, &offset)) {
+		// Offset already follows MATCH.
+	} else if (StartsWithGqlKeywords(query, {"MATCH"}, &offset)) {
+		// Offset already follows MATCH.
 	} else {
 		return;
 	}
-	while (offset < trimmed.size() && std::isspace(static_cast<unsigned char>(trimmed[offset]))) {
+	while (offset < query.size() && std::isspace(static_cast<unsigned char>(query[offset]))) {
 		offset++;
 	}
-	if (offset + 3 > trimmed.size() || trimmed.compare(offset, 3, "/*+") != 0) {
+	if (offset + 3 > query.size() || query.compare(offset, 3, "/*+") != 0) {
 		return;
 	}
-	auto end = trimmed.find("*/", offset + 3);
+	auto end = query.find("*/", offset + 3);
 	if (end == string::npos) {
 		throw ParserException("Unterminated GQL execution hint");
 	}
-	auto hint = trimmed.substr(offset + 3, end - offset - 3);
+	auto hint = query.substr(offset + 3, end - offset - 3);
 	StringUtil::Trim(hint);
 	hint = StringUtil::Upper(hint);
 	if (hint == "CSR" || hint == "GQL_CSR") {
@@ -1328,8 +1353,7 @@ ParserExtensionParseResult GqlParse(ParserExtensionInfo *, const string &query) 
 	}
 
 	auto gql_query = StripTerminator(query);
-	auto normalized = NormalizedGqlStart(gql_query);
-	if (StringUtil::StartsWith(normalized, "COPY GRAPH")) {
+	if (StartsWithGqlKeywords(gql_query, {"COPY", "GRAPH"})) {
 		auto parse_data = make_uniq<GqlParseData>();
 		parse_data->query = gql_query;
 		parse_data->statement = CopyGraphParser(gql_query).Parse();
@@ -1569,8 +1593,8 @@ static bool TryParseGqlExplain(const string &query, ParserOptions &options, GqlE
 	}
 
 	auto inner_query = query.substr(inner_offset);
-	auto upper = NormalizedGqlStart(inner_query);
-	auto is_match = StringUtil::StartsWith(upper, "MATCH") || StringUtil::StartsWith(upper, "OPTIONAL MATCH");
+	auto is_match =
+	    StartsWithGqlKeywords(inner_query, {"MATCH"}) || StartsWithGqlKeywords(inner_query, {"OPTIONAL", "MATCH"});
 	if (!is_match && !StartsWithAlgorithmCall(inner_query)) {
 		if (StartsWithGqlCommand(inner_query)) {
 			throw NotImplementedException("DuckGQL EXPLAIN currently supports MATCH and CALL algo.* queries");
@@ -1712,9 +1736,8 @@ ParserOverrideResult GqlParserOverride(ParserExtensionInfo *, const string &quer
 		}
 		return ParserOverrideResult(std::move(parser.statements));
 	}
-	auto normalized = NormalizedGqlStart(query);
-	if (!StartsWithMergePattern(query) && !StringUtil::StartsWith(normalized, "INSERT (") &&
-	    !StringUtil::StartsWith(normalized, "MATCH") && !StringUtil::StartsWith(normalized, "OPTIONAL MATCH") &&
+	if (!StartsWithMergePattern(query) && !StartsWithGqlKeywordsAndCharacter(query, {"INSERT"}, '(') &&
+	    !StartsWithGqlKeywords(query, {"MATCH"}) && !StartsWithGqlKeywords(query, {"OPTIONAL", "MATCH"}) &&
 	    !StartsWithAlgorithmCall(query)) {
 		return ParserOverrideResult();
 	}

--- a/src/gql_transformer.cpp
+++ b/src/gql_transformer.cpp
@@ -179,7 +179,10 @@ std::any GqlTransformer::visitSessionSetGraphClause(GQLParser::SessionSetGraphCl
 }
 
 std::any GqlTransformer::visitInsertStatement(GQLParser::InsertStatementContext *context) {
-	statement = TransformInsert(*context, false);
+	auto insert = TransformInsert(*context, false);
+	if (insert) {
+		statement = std::move(insert);
+	}
 	return {};
 }
 
@@ -295,7 +298,9 @@ bool GqlTransformer::TransformCall(GQLParser::GqlProgramContext &root) {
 	CollectContexts(&root, return_statements);
 	CollectContexts(&root, order_statements);
 	auto fail = [&]() {
-		Unsupported(root, "CALL/YIELD/RETURN procedure pipeline");
+		if (!statement) {
+			Unsupported(root, "CALL/YIELD/RETURN procedure pipeline");
+		}
 		return false;
 	};
 	if (procedure_calls.size() != 1 || return_statements.size() != 1 || order_statements.size() > 1) {
@@ -365,25 +370,49 @@ bool GqlTransformer::TransformCall(GQLParser::GqlProgramContext &root) {
 	}
 
 	auto body = return_statements[0]->returnStatementBody();
-	if (!body || body->ASTERISK() || !body->returnItemList() || body->groupByClause()) {
+	if (!body || body->groupByClause() || (!body->ASTERISK() && !body->returnItemList())) {
 		return fail();
 	}
 	if (body->setQuantifier()) {
 		call->distinct = body->setQuantifier()->DISTINCT() != nullptr;
 	}
 	std::unordered_set<string> projection_names;
-	for (auto item : body->returnItemList()->returnItem()) {
-		GqlProjection projection;
-		if (!TransformProjection(item, projection) ||
-		    projection.expression->type != GqlExpressionType::VARIABLE_REFERENCE ||
-		    yielded_names.find(projection.expression->variable.value) == yielded_names.end()) {
-			return fail();
+	if (body->ASTERISK()) {
+		vector<const GqlYieldItem *> sorted_yields;
+		for (const auto &yield_item : call->yield_items) {
+			sorted_yields.push_back(&yield_item);
 		}
-		auto output_name = projection.alias.IsEmpty() ? projection.expression->variable.value : projection.alias.value;
-		if (!projection_names.insert(output_name).second) {
-			return fail();
+		std::sort(sorted_yields.begin(), sorted_yields.end(), [](const GqlYieldItem *left, const GqlYieldItem *right) {
+			auto left_name = left->alias.IsEmpty() ? left->field.value : left->alias.value;
+			auto right_name = right->alias.IsEmpty() ? right->field.value : right->alias.value;
+			return left_name < right_name;
+		});
+		for (const auto yield_item : sorted_yields) {
+			auto output_name = yield_item->alias.IsEmpty() ? yield_item->field.value : yield_item->alias.value;
+			GqlProjection projection;
+			projection.expression = make_shared_ptr<GqlExpression>();
+			projection.expression->type = GqlExpressionType::VARIABLE_REFERENCE;
+			projection.expression->variable.value = output_name;
+			projection.expression->variable.source = yield_item->source;
+			projection.expression->source = yield_item->source;
+			projection.source = yield_item->source;
+			call->projections.push_back(std::move(projection));
 		}
-		call->projections.push_back(std::move(projection));
+	} else {
+		for (auto item : body->returnItemList()->returnItem()) {
+			GqlProjection projection;
+			if (!TransformProjection(item, projection) ||
+			    projection.expression->type != GqlExpressionType::VARIABLE_REFERENCE ||
+			    yielded_names.find(projection.expression->variable.value) == yielded_names.end()) {
+				return fail();
+			}
+			auto output_name =
+			    projection.alias.IsEmpty() ? projection.expression->variable.value : projection.alias.value;
+			if (!projection_names.insert(output_name).second) {
+				return fail();
+			}
+			call->projections.push_back(std::move(projection));
+		}
 	}
 	if (call->projections.empty()) {
 		return fail();
@@ -454,7 +483,9 @@ bool GqlTransformer::TransformMatch(GQLParser::GqlProgramContext &root) {
 		return false;
 	}
 	auto fail = [&]() {
-		Unsupported(root, "MATCH pattern or projection");
+		if (!statement) {
+			Unsupported(root, "MATCH pattern or projection");
+		}
 		return false;
 	};
 	auto base_primitives = match_statements.size() + let_statements.size() + filter_statements.size();
@@ -824,24 +855,31 @@ bool GqlTransformer::TransformMatch(GQLParser::GqlProgramContext &root) {
 	}
 
 	auto body = return_statements[0]->returnStatementBody();
-	if (body->ASTERISK() || !body->returnItemList()) {
+	if (!body->ASTERISK() && !body->returnItemList()) {
+		return fail();
+	}
+	if (body->ASTERISK() && body->groupByClause()) {
 		return fail();
 	}
 	if (body->setQuantifier()) {
 		match->distinct = body->setQuantifier()->DISTINCT() != nullptr;
 	}
-	for (auto item : body->returnItemList()->returnItem()) {
-		GqlProjection projection;
-		if (!TransformProjection(item, projection)) {
-			return fail();
+	if (body->ASTERISK()) {
+		match->return_all = true;
+	} else {
+		for (auto item : body->returnItemList()->returnItem()) {
+			GqlProjection projection;
+			if (!TransformProjection(item, projection)) {
+				return fail();
+			}
+			if (!procedure_calls.empty() &&
+			    (!projection.expression || projection.expression->type != GqlExpressionType::VARIABLE_REFERENCE)) {
+				return fail();
+			}
+			match->projections.push_back(std::move(projection));
 		}
-		if (!procedure_calls.empty() &&
-		    (!projection.expression || projection.expression->type != GqlExpressionType::VARIABLE_REFERENCE)) {
-			return fail();
-		}
-		match->projections.push_back(std::move(projection));
 	}
-	if (match->projections.empty()) {
+	if (!match->return_all && match->projections.empty()) {
 		return fail();
 	}
 	if (auto group_by = body->groupByClause()) {
@@ -1152,6 +1190,7 @@ bool GqlTransformer::TransformLabelExpression(GQLParser::LabelExpressionContext 
                                               vector<GqlIdentifier> &labels) {
 	if (auto name = dynamic_cast<GQLParser::LabelExpressionNameContext *>(&context)) {
 		if (!IsRegularIdentifier(name->labelName()->getText())) {
+			Unsupported(*name, "delimited labels in MATCH");
 			return false;
 		}
 		labels.push_back(TransformIdentifier(*name->labelName()));
@@ -1179,6 +1218,7 @@ bool GqlTransformer::TransformProjection(GQLParser::ReturnItemContext *item, Gql
 	result.source = SourceRange(*item);
 	if (auto alias = item->returnItemAlias()) {
 		if (!IsRegularIdentifier(alias->identifier()->getText())) {
+			Unsupported(*alias, "delimited RETURN aliases");
 			return false;
 		}
 		result.alias = TransformIdentifier(*alias->identifier());
@@ -1382,8 +1422,11 @@ bool GqlTransformer::TransformExpressionPrimary(GQLParser::ValueExpressionPrimar
 		return true;
 	}
 	if (context.propertyName() && context.valueExpressionPrimary()) {
-		if (!IsRegularIdentifier(context.propertyName()->getText()) ||
-		    !TransformExpressionPrimary(*context.valueExpressionPrimary(), expression->left)) {
+		if (!IsRegularIdentifier(context.propertyName()->getText())) {
+			Unsupported(context, "delimited property references");
+			return false;
+		}
+		if (!TransformExpressionPrimary(*context.valueExpressionPrimary(), expression->left)) {
 			return false;
 		}
 		expression->type = GqlExpressionType::PROPERTY_REFERENCE;
@@ -1840,20 +1883,6 @@ void GqlTransformer::Unsupported(antlr4::ParserRuleContext &context, const strin
 }
 
 bool GqlTransformer::IsRegularIdentifier(const string &value) {
-	if (value.size() >= 2 &&
-	    ((value.front() == '"' && value.back() == '"') || (value.front() == '`' && value.back() == '`'))) {
-		auto quote = value.front();
-		for (idx_t index = 1; index + 1 < value.size(); index++) {
-			if (value[index] != quote) {
-				continue;
-			}
-			if (index + 2 >= value.size() || value[index + 1] != quote) {
-				return false;
-			}
-			index++;
-		}
-		return true;
-	}
 	if (value.empty() || !(std::isalpha(static_cast<unsigned char>(value[0])) || value[0] == '_')) {
 		return false;
 	}

--- a/src/include/gql_ast.hpp
+++ b/src/include/gql_ast.hpp
@@ -351,6 +351,7 @@ public:
 	vector<GqlMutation> mutations;
 	shared_ptr<GqlInsertStatement> insertion;
 	bool has_mutation = false;
+	bool return_all = false;
 	bool distinct = false;
 	bool has_offset = false;
 	bool has_limit = false;

--- a/test/sql/gql_basic_query.test
+++ b/test/sql/gql_basic_query.test
@@ -154,9 +154,41 @@ Ada	Ada
 Ada	Ada
 Grace	Grace
 
+# NULL is neutral while COALESCE selects and validates its concrete result
+# type, regardless of argument order.
+query T
+MATCH (person:Person) WHERE person.age = 42
+RETURN COALESCE(NULL, 'unknown') AS display_name
+----
+unknown
+
+query T
+MATCH (person:Person) WHERE person.age = 42
+RETURN COALESCE('known', NULL) AS display_name
+----
+known
+
+query T
+MATCH (person:Person) WHERE person.age = 42
+RETURN COALESCE(NULL, person.name) AS display_name
+----
+Ada
+
+query I
+MATCH (person:Person) WHERE person.age = 42
+RETURN COALESCE(NULL, NULL) AS missing
+----
+NULL
+
 query T
 OPTIONAL MATCH (person:Missing)
 RETURN person.name AS name
+----
+NULL
+
+query I
+OPTIONAL MATCH (person:Missing)
+RETURN element_id(person) AS person_id
 ----
 NULL
 
@@ -310,6 +342,40 @@ RETURN source.name AS source_name, target.name AS target_name
 ----
 Ada	Grace
 Grace	Ada
+
+# RETURN * expands visible names in ascending order.
+query TTT
+MATCH (person:Person)-[knows:KNOWS]->(friend:Person)
+WHERE element_id(person) = 1
+RETURN *
+----
+{'vertex_id': 2, '__gql_labels': person, 'age': 35, 'name': Grace}	{'edge_id': 1, '__gql_type': knows, '__gql_source': 1, '__gql_target': 2}	{'vertex_id': 1, '__gql_labels': person, 'age': 42, 'name': Ada}
+
+query TT
+MATCH (source:Person) WHERE source.age = 30
+OPTIONAL MATCH (source)-[:MISSING]->(target:Person)
+RETURN *
+----
+{'vertex_id': 3, '__gql_labels': person, 'age': 30, 'name': Ada}	NULL
+
+query TT
+MATCH (person:Person) WHERE person.age = 42
+LET display_name = person.name
+RETURN *
+----
+Ada	{'vertex_id': 1, '__gql_labels': person, 'age': 42, 'name': Ada}
+
+statement error
+MATCH ()
+RETURN *
+----
+<REGEX>:.*GQL RETURN \* requires at least one visible variable.*
+
+statement error
+MATCH (person:Person)
+RETURN * GROUP BY person
+----
+<REGEX>:.*GQL feature not implemented: MATCH pattern or projection.*
 
 # FILTER ownership also follows clause order across OPTIONAL MATCH stages.
 query TT

--- a/test/sql/gql_csr_algorithms.test
+++ b/test/sql/gql_csr_algorithms.test
@@ -93,6 +93,16 @@ CALL algo.bfs('algo_graph', 1)
 4	2	2	3	3
 5	3	4	5	4
 
+# RETURN * expands yielded columns by ascending name.
+query II
+CALL algo.bfs('algo_graph', 1)
+YIELD vertex_id, depth
+RETURN *
+LIMIT 2
+----
+0	1
+1	2
+
 # DFS uses an iterative frame stack and deterministic CSR adjacency order.
 query IIIII
 CALL algo.dfs('algo_graph', 1)

--- a/test/sql/gql_feature_compatibility.test
+++ b/test/sql/gql_feature_compatibility.test
@@ -3080,7 +3080,7 @@ COPY (
         ('n14', 13, ''),
         ('n15', 14, ''),
         ('n16', 15, '')
-    ) fixture(":ID(GqlFixture_candidate_returnskiplimit3_84)", "count:long", ":LABEL")
+    ) fixture(":ID(GqlFixture_candidate_returnskiplimit3_84)", "value_count:long", ":LABEL")
 ) TO '__TEST_DIR__/candidate_returnskiplimit3_84_nodes.csv' (FORMAT CSV, HEADER)
 
 statement ok
@@ -3102,8 +3102,8 @@ SESSION SET GRAPH candidate_returnskiplimit3_84
 
 query I
 MATCH (a)
-RETURN a."count"
-ORDER BY a."count"
+RETURN a.value_count
+ORDER BY a.value_count
 OFFSET 10
 LIMIT 10
 ----
@@ -3710,7 +3710,7 @@ SESSION SET GRAPH candidate_return6_33
 
 query II rowsort
 MATCH (n)
-RETURN n.num AS n, count(n) AS "count"
+RETURN n.num AS n, count(n) AS result_count
 ----
 42	1
 
@@ -10994,7 +10994,7 @@ SESSION SET GRAPH candidate_return6_82
 
 query I rowsort
 MATCH (n)
-RETURN count(n) / 60 / 60 AS "count"
+RETURN count(n) / 60 / 60 AS result_count
 ----
 2
 

--- a/test/sql/gql_parser.test
+++ b/test/sql/gql_parser.test
@@ -10,7 +10,7 @@ SELECT 42
 42
 
 query IT
-create graph MiXeD any;
+CREATE /* lifecycle command trivia */ GRAPH MiXeD ANY;
 ----
 true	mixed
 
@@ -45,12 +45,60 @@ MATCH (n) RETURN n
 ----
 <REGEX>:.*No graph selected; use SESSION SET GRAPH before MATCH.*
 
+# Dispatch uses the same trivia rules as the GQL lexer between keywords and
+# before an INSERT pattern.
+statement error
+OPTIONAL
+/* match keyword trivia */ MATCH (n)
+RETURN n
+----
+<REGEX>:.*No graph selected; use SESSION SET GRAPH before MATCH.*
+
+statement error
+INSERT
+/* pattern trivia */ (:Person)
+----
+<REGEX>:.*No graph selected; use SESSION SET GRAPH before mutation.*
+
 # Leading lexical trivia must not make the parser override miss GQL.
 statement error
 /* leading GQL comment */
 MATCH (n) RETURN n
 ----
 <REGEX>:.*No graph selected; use SESSION SET GRAPH before MATCH.*
+
+statement error
+// leading solidus comment
+MATCH (n) RETURN n
+----
+<REGEX>:.*No graph selected; use SESSION SET GRAPH before MATCH.*
+
+# Delimited names are rejected consistently until their canonicalization is
+# supported throughout storage, matching, and projection.
+statement error
+CREATE GRAPH `Mixed Graph` ANY
+----
+<REGEX>:.*GQL feature not implemented: delimited graph names.*
+
+statement error
+MATCH (n:`Person Label`) RETURN n
+----
+<REGEX>:.*GQL feature not implemented: delimited labels in MATCH.*
+
+statement error
+MATCH (n) RETURN n.`First Name`
+----
+<REGEX>:.*GQL feature not implemented: delimited property references.*
+
+statement error
+MATCH (n) RETURN n AS `Node Alias`
+----
+<REGEX>:.*GQL feature not implemented: delimited RETURN aliases.*
+
+statement error
+INSERT (n:`Person Label`)
+----
+<REGEX>:.*GQL feature not implemented: delimited labels in INSERT.*
 
 # Parser overrides receive the complete query string. Split mixed batches before
 # lowering so a lifecycle statement cannot force a following MATCH down the
@@ -61,6 +109,7 @@ SESSION SET GRAPH mixed; MATCH (n) RETURN n;
 <REGEX>:.*Graph 'mixed' has no native tables.*
 
 query IT
-DROP GRAPH mixed
+DROP
+/* lifecycle command trivia */ GRAPH mixed
 ----
 true	mixed


### PR DESCRIPTION
## Summary

- make GQL statement dispatch follow lexer trivia rules, including comments and line breaks between keywords
- combine COALESCE argument types with NULL as the immaterial null type
- apply one explicit policy for unsupported delimited identifiers across graph, label, property, and alias contexts
- propagate OPTIONAL MATCH nullability through bindings and ELEMENT_ID
- expand RETURN * from visible variables in ascending column-name order, including YIELD pipelines

## Root cause

Statement routing used literal text prefixes that were narrower than the lexer. Type binding seeded COALESCE from its first argument and hard-coded non-null element identifiers. Identifier validation treated delimited spellings as regular names without a consistent canonical-name policy. The transformed MATCH representation discarded the asterisk return alternative.

## Impact

Valid trivia no longer changes statement routing, NULL arguments no longer make COALESCE order-dependent, optional element identifiers correctly return nullable results, unsupported delimited names fail consistently, and RETURN * follows the ISO-defined visible-column ordering.

## Validation

- debug unittest target built successfully with GCC 11; the local linker required allowing identical definitions already emitted by the baseline extension build
- focused parser, basic-query, CSR, and feature-compatibility files passed 1,568 assertions
- the remaining 15 GQL SQLLogicTest files passed in the suite run
- conformance check validated 36 ISO GQL feature families and 571 parser rules
- clang-format and whitespace checks passed

Closes #1
Closes #2
Closes #3
Closes #4
Closes #5